### PR TITLE
Revise add theme switching

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -178,7 +178,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pH) : QDialog(pF
     connect(reset_colors_button, &QAbstractButton::clicked, this, &dlgProfilePreferences::resetColors);
     connect(reset_colors_button_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::resetColors2);
 
-    connect(fontComboBox, SIGNAL(currentFontChanged(const QFont&)), this, SLOT(slot_setDisplayFont()));
+    connect(fontComboBox, SIGNAL(currentFontChanged(const QFont&)), this, SLOT(setDisplayFont()));
     QStringList sizeList;
     for (int i = 1; i < 40; i++) {
         sizeList << QString::number(i);
@@ -1426,7 +1426,9 @@ void dlgProfilePreferences::slot_save_and_exit()
 
     pHost->mEditorTheme = code_editor_theme_selection_combobox->currentText();
     pHost->mEditorThemeFile = code_editor_theme_selection_combobox->currentData().toString();
-    mudlet::self()->setEditorTheme(pHost->mEditorTheme);
+    if (pHost->mpEditorDialog) {
+        pHost->mpEditorDialog->setThemeAndOtherSettings(pHost->mEditorTheme);
+    }
 
     auto data = script_preview_combobox->currentData().value<QPair<QString, int>>();
     pHost->mThemePreviewItemID = data.second;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -79,6 +79,13 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pH) : QDialog(pF
     checkBox_echoLuaErrors->setChecked(pH->mEchoLuaErrors);
     checkBox_showSpacesAndTabs->setChecked(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces);
     checkBox_showLineFeedsAndParagraphs->setChecked(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
+    // As we reflect the state of the above two checkboxes in the preview widget
+    // on another tab we have to track their changes in state and update that
+    // edbee widget straight away - however we do not need to update any open
+    // widgets of the same sort in use in ANY profile's editor until we hit
+    // the save button...
+    connect(checkBox_showSpacesAndTabs, SIGNAL(clicked(bool)), this, SLOT(slot_changeShowSpacesAndTabs(const bool)));
+    connect(checkBox_showLineFeedsAndParagraphs, SIGNAL(clicked(bool)), this, SLOT(slot_changeShowLineFeedsAndParagraphs(const bool)));
 
     QString path;
 #ifdef Q_OS_LINUX
@@ -171,7 +178,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pH) : QDialog(pF
     connect(reset_colors_button, &QAbstractButton::clicked, this, &dlgProfilePreferences::resetColors);
     connect(reset_colors_button_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::resetColors2);
 
-    connect(fontComboBox, SIGNAL(currentFontChanged(const QFont&)), this, SLOT(setDisplayFont()));
+    connect(fontComboBox, SIGNAL(currentFontChanged(const QFont&)), this, SLOT(slot_setDisplayFont()));
     QStringList sizeList;
     for (int i = 1; i < 40; i++) {
         sizeList << QString::number(i);
@@ -380,13 +387,13 @@ void dlgProfilePreferences::loadEditorTab()
     config->setIndentSize(2);
     config->setThemeName(mpHost->mEditorTheme);
     config->setCaretWidth(1);
-    config->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces);
+    config->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
+    config->setFont(mpHost->mDisplayFont);
     config->endChanges();
     edbeePreviewWidget->textDocument()->setLanguageGrammar(edbee::Edbee::instance()->grammarManager()->detectGrammarWithFilename(QLatin1Literal("Buck.lua")));
     // disable shadows as their purpose (notify there is more text) is performed by scrollbars already
     edbeePreviewWidget->textScrollArea()->enableShadowWidget(false);
-    edbeePreviewWidget->config()->setFont(mpHost->mDisplayFont);
 
     populateThemesList();
     mudlet::loadEdbeeTheme(mpHost->mEditorTheme, mpHost->mEditorThemeFile);
@@ -631,11 +638,19 @@ void dlgProfilePreferences::setDisplayFont()
     }
     QFont font = fontComboBox->currentFont();
     font.setPointSize(mFontSize);
-    pHost->mDisplayFont = font;
-    if (mudlet::self()->mConsoleMap.contains(pHost)) {
-        mudlet::self()->mConsoleMap[pHost]->changeColors();
+    if (pHost->mDisplayFont != font) {
+        pHost->mDisplayFont = font;
+        if (mudlet::self()->mConsoleMap.contains(pHost)) {
+            mudlet::self()->mConsoleMap[pHost]->changeColors();
+        }
+        auto config = edbeePreviewWidget->config();
+        config->beginChanges();
+        config->setFont(font);
+        config->endChanges();
     }
 }
+
+// Currently UNUSED!
 void dlgProfilePreferences::setCommandLineFont()
 {
     Host* pHost = mpHost;
@@ -1400,6 +1415,11 @@ void dlgProfilePreferences::slot_save_and_exit()
         QApplication::sendEvent(mudlet::self()->mConsoleMap[pHost], &event);
         //qDebug()<<"after console refresh: Left border width:"<<pHost->mBorderLeftWidth<<" right:"<<pHost->mBorderRightWidth;
     }
+
+    // These are only sent on saving because they are application wide and
+    // will affect all editors even the ones of other profiles so, if two
+    // profile both had their preferences open they would fight each other if
+    // they changed things at the same time:
     mudlet::self()->setEditorTextoptions(checkBox_showSpacesAndTabs->isChecked(), checkBox_showLineFeedsAndParagraphs->isChecked());
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
     pHost->mEchoLuaErrors = checkBox_echoLuaErrors->isChecked();
@@ -1617,7 +1637,10 @@ void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
     QSettings settings("mudlet", "Mudlet");
     QString themesURL = settings.value("colorSublimeThemesURL", QStringLiteral("https://github.com/Colorsublime/Colorsublime-Themes/archive/master.zip")).toString();
     // a default update period is 24h
-    int themesUpdatePeriod = settings.value("themesUpdatePeriod", 86'400'000).toInt();
+    // it would be nice to use C++14's numeric separator but Qt Creator still
+    // does not like them for its Clang code model analyser (and the built in
+    // one is even less receptive to): 86'400'000
+    int themesUpdatePeriod = settings.value("themesUpdatePeriod", 86400000).toInt();
     // save the defaults in settings so the field is visible for editing in config file if needed
     settings.setValue("colorSublimeThemesURL", themesURL);
     settings.setValue("themesUpdatePeriod", themesUpdatePeriod);
@@ -1648,9 +1671,9 @@ void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
 
     QNetworkReply* getReply = manager->get(request);
 
-    connect(getReply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), [=](QNetworkReply::NetworkError code) {
-        theme_download_label->setText(tr("Couldn't update themes: %1").arg(getReply->errorString()));
-        QTimer::singleShot(5'000, theme_download_label, [label = theme_download_label] {
+    connect(getReply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), [=](QNetworkReply::NetworkError) {
+        theme_download_label->setText(tr("Could not update themes: %1").arg(getReply->errorString()));
+        QTimer::singleShot(5000, theme_download_label, [label = theme_download_label] {
             label->hide();
             label->setText(tr("Updating themes from colorsublime.com..."));
         });
@@ -1778,4 +1801,42 @@ void dlgProfilePreferences::slot_script_selected(int index)
     } else if (itemType == QStringLiteral("button")) {
         preview->setText(mpHost->getActionUnit()->getAction(itemId)->getScript());
     }
+}
+
+/*!
+ * \brief dlgProfilePreferences::slot_changeShowSpacesAndTabs
+ * \param state \c true to show whitespace (dots for spaces, right arrows for tabs)
+ * \c false to hide them and show just normal space
+ *
+ * A private slot function that adjusts the display of spaces and tab in the
+ * editor preview in the "Editor" tab
+ */
+void dlgProfilePreferences::slot_changeShowSpacesAndTabs(const bool state)
+{
+    qDebug() << "dlgProfilePreferences::slot_changeShowSpacesAndTabs("
+             << state
+             << ") called, updating PREVIEW of editor for:"
+             << mpHost->getName();
+
+    auto config = edbeePreviewWidget->config();
+    config->beginChanges();
+    config->setShowWhitespaceMode(state ? 1 : 0);
+    config->endChanges();
+}
+
+/*!
+ * \brief dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs
+ * \param state
+ */
+void dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs(const bool state)
+{
+    qDebug() << "dlgProfilePreferences::slot_showLineFeedsAndParagraphs("
+             << state
+             << ") called, updating PREVIEW of editor for:"
+             << mpHost->getName();
+
+    auto config = edbeePreviewWidget->config();
+    config->beginChanges();
+    config->setUseLineSeparator(state);
+    config->endChanges();
 }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1815,11 +1815,6 @@ void dlgProfilePreferences::slot_script_selected(int index)
  */
 void dlgProfilePreferences::slot_changeShowSpacesAndTabs(const bool state)
 {
-    qDebug() << "dlgProfilePreferences::slot_changeShowSpacesAndTabs("
-             << state
-             << ") called, updating PREVIEW of editor for:"
-             << mpHost->getName();
-
     auto config = edbeePreviewWidget->config();
     config->beginChanges();
     config->setShowWhitespaceMode(state ? 1 : 0);
@@ -1828,15 +1823,16 @@ void dlgProfilePreferences::slot_changeShowSpacesAndTabs(const bool state)
 
 /*!
  * \brief dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs
- * \param state
+ * \param state \c true to show (currently) a graphic line under each line of text in editor
+ * \c false to hide them.
+ *
+ * A private slot function that (currently) adjusts the display of a horizontal
+ * "underline" acros the width of each line of text in the editor preview in the
+ * "Editor" tab although it was originally intended to show line-feeds and paragraph
+ * markers in the previous QTextEdit (and may in the future in the edbee) widget.
  */
 void dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs(const bool state)
 {
-    qDebug() << "dlgProfilePreferences::slot_showLineFeedsAndParagraphs("
-             << state
-             << ") called, updating PREVIEW of editor for:"
-             << mpHost->getName();
-
     auto config = edbeePreviewWidget->config();
     config->beginChanges();
     config->setUseLineSeparator(state);

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -114,6 +114,9 @@ public slots:
     void hideActionLabel();
     void slot_setEncoding(const QString&);
 
+private slots:
+    void slot_changeShowSpacesAndTabs(const bool);
+    void slot_changeShowLineFeedsAndParagraphs(const bool);
 
 private:
     void setColors();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6406,8 +6406,13 @@ void dlgTriggerEditor::slot_changeEditorTextOptions(QTextOption::Flags state)
 {
     edbee::TextEditorConfig* config = mpSourceEditorEdbee->config();
 
-    config->setShowWhitespaceMode(state & QTextOption::ShowTabsAndSpaces);
+    // Although this option seems to be a binary choice the Edbee editor widget
+    // needs a integer 1 to show whitespace characters and an integer 0 to hide
+    // them:
+    config->beginChanges();
+    config->setShowWhitespaceMode(state & QTextOption::ShowTabsAndSpaces ? 1 : 0);
     config->setUseLineSeparator(state & QTextOption::ShowLineAndParagraphSeparators);
+    config->endChanges();
 }
 
 //

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -427,14 +427,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     config->beginChanges();
     config->setThemeName(mpHost->mEditorTheme);
     config->setFont(mpHost->mDisplayFont);
+    config->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+    config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->endChanges();
-    connect(mudlet::self(), &mudlet::signal_editorThemeChanged, this, [=](const QString& theme) {
-        auto config = mpSourceEditorEdbee->config();
-        config->beginChanges();
-        config->setThemeName(theme);
-        config->setFont(mpHost->mDisplayFont);
-        config->endChanges();
-    });
 
     connect(comboBox_searchTerms, SIGNAL(activated(const QString)), this, SLOT(slot_search_triggers(const QString)));
     connect(treeWidget_triggers, SIGNAL(itemClicked(QTreeWidgetItem*, int)), this, SLOT(slot_trigger_selected(QTreeWidgetItem*)));
@@ -6431,9 +6426,32 @@ void dlgTriggerEditor::clearDocument(edbee::TextEditorWidget* ew, const QString&
     mpSourceEditorEdbeeDocument->setLanguageGrammar(edbee::Edbee::instance()->grammarManager()->detectGrammarWithFilename(QLatin1Literal("Buck.lua")));
     ew->controller()->giveTextDocument(mpSourceEditorEdbeeDocument);
 
+    auto config = mpSourceEditorEdbee->config();
+    config->beginChanges();
+    config->setThemeName(mpHost->mEditorTheme);
+    config->setFont(mpHost->mDisplayFont);
+    config->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+    config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
+    config->endChanges();
+
     // If undo is not disabled when setting the initial text, the
     // setting of the text will be undoable.
     mpSourceEditorEdbeeDocument->setUndoCollectionEnabled(false);
     mpSourceEditorEdbeeDocument->setText(initialText);
     mpSourceEditorEdbeeDocument->setUndoCollectionEnabled(true);
 }
+
+// We do NOT want to change every profile's editor theme when the setting is
+// changed in the settings dialog so this has been moved out of a lambda wired
+// up as a slot to respond to a
+// mudlet::signal_editorThemeChanged(const QString& theme) signal
+void dlgTriggerEditor::setThemeAndOtherSettings(const QString& theme)
+{
+        auto localConfig = mpSourceEditorEdbee->config();
+        localConfig->beginChanges();
+        localConfig->setThemeName(theme);
+        localConfig->setFont(mpHost->mDisplayFont);
+        localConfig->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+        localConfig->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
+        localConfig->endChanges();
+};

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -112,6 +112,7 @@ public:
     void recurseVariablesDown(QTreeWidgetItem* const, QList<QTreeWidgetItem*>&);
     void recurseVariablesDown(TVar*, QList<TVar*>&, bool);
     void show_vars();
+    void setThemeAndOtherSettings(const QString&);
 
 public slots:
     void slot_toggleHiddenVariables(bool);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2778,12 +2778,6 @@ void mudlet::setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const boo
     emit signal_editorTextOptionsChanged(mEditorTextOptions);
 }
 
-
-void mudlet::setEditorTheme(const QString& theme)
-{
-    emit signal_editorThemeChanged(theme);
-}
-
 void mudlet::slot_statusBarMessageChanged(QString text)
 {
     if (mStatusBarState & statusBarAutoShown) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -194,7 +194,6 @@ public:
     // are considered/used/stored
     QTextOption::Flags mEditorTextOptions;
     void setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const bool isLinesAndParagraphsToBeShown);
-    void setEditorTheme(const QString &theme);
     static bool loadEdbeeTheme(const QString &themeName, const QString &themeFile);
 
     enum StatusBarOption {
@@ -262,7 +261,6 @@ protected:
 
 signals:
     void signal_editorTextOptionsChanged(QTextOption::Flags);
-    void signal_editorThemeChanged(QString);
     void signal_profileMapReloadRequested(QList<QString>);
 
 private slots:


### PR DESCRIPTION
These commits make changing the showTabs/Spaces and the showLineFeeds/Paragraph settings in one tab of the Profile Preferences dialogue apply immediately to the preview "Editor" widget in another tab whilst the dialogue is up (it is pointless to not make the change until the dialogue is closed as it make that aspect of the preview not be previewable!)

These commits also removes the signal/slot code that caused the selected "theme" to be applied to ALL active profiles instead of just the current one - the latter I inferred from the fact that the theme name is stored on a per profile basis...!  At the same time I found out that the undo/redo "workaround" code as `dlgTriggerEditor::clearDocument()` meant that the theme and white space markers did not survive the item being selected in the Editor changing!

As a side point I notice that if the `Host::displayFont` was changed in the Profile Preferences it was not being reflected in the preview edbee widget either.

Sadly the Qt Creator IDE's code models (built in or Clang-plugin) do not (yet) tolerate all aspects of C++14 - specifically the `'` number group separator - so I undid a couple of placed where I found this new feature in place (complete with red error markings).

Finally I discovered a bug in the upstream code that controlled whether to show or hide the tab and space whitespace marks was not being recorded as something to flag a redraw when this setting was changed - the third commit updates the local instance of the edbee-lib git submodule to tracked this and a couple of other updates to the library.