### PR TITLE
Revise: further tweaks to text selection/deselection code

### DIFF
--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -78,7 +78,7 @@ public:
     void showEvent(QShowEvent* event) override;
     void updateScreenView();
     void highlight();
-    void unHighlight(QRegion&);
+    void unHighlight();
     void swap(QPoint& p1, QPoint& p2);
     void focusInEvent(QFocusEvent* event) override;
     int imageTopLine();
@@ -136,7 +136,7 @@ private:
     bool mCtrlSelecting;
     int mDragStartY;
     int mOldScrollPos;
-    QPoint mP_aussen;
+
     QPoint mPA;
     bool mPainterInit;
     QPoint mPB;


### PR DESCRIPTION
We now mark a line of text as being "dirty" when doing highlighting only if we make a change to the `TCHAR_INVERSE` bit of any of the `TChar` that represents the attributes for each character (or more properly `QChar`) that is being selected/deselected.

We currently use the `TCHAR_INVERSE` flag bit to indicate selection state though I do have plans long term to add a separate `TCHAR_SELECTED` bit to the existing bit field so that we can handle the ANSI ESC SGR codes for reverse/normal video - then for final display these pair of bits will be EX_ORed to determine whether a particular character is drawn with fore and back ground colours swapped!

Also: remove unused `(QPoint) TTextEdit::mP_aussen` and a `QRegion&` argument to `(void)TTextEdit::unhighlight()`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>