### PR TITLE
BugFix: tweak some issues when not wanting to include updater code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
-#    Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    #
+#    Copyright (C) 2015-2017 by Stephen Lyons - slysven@virginmedia.com    #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -68,21 +68,64 @@ ENDIF()
 
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
-ADD_SUBDIRECTORY(3rdparty/communi)
-ADD_SUBDIRECTORY(3rdparty/lua_yajl)
-ADD_SUBDIRECTORY(3rdparty/dblsqd)
+# Enable the built-in updater by default unless NO_INCLUDE_UPDATER is
+# already defined. Linux packagers will find it useful to do this since
+# package managers are responsible for updates there. Automatically exclude
+# the update stuff from FreeBSD and Cygwin because if they ever get finished
+# they have their own packaging system
+IF((DEFINED ENV{NO_INCLUDE_UPDATER} AND NOT $ENV{MUDLET_VERSION_BUILD} STREQUAL "") OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") OR (CMAKE_SYSTEM_NAME STREQUAL "Cygwin"))
+  OPTION(WITH_UPDATER "Include libraries and code to allow release versions to be updated on demand" OFF)
+ELSE()
+  OPTION(WITH_UPDATER "Include libraries and code to allow release versions to be updated on demand" ON)
+ENDIF()
+
 IF(APPLE)
   # Needed (just) on MacOs as an #include in luazip.h:
   ADD_SUBDIRECTORY(3rdparty/luazip)
-  # Add Sparkle glue as well
-  ADD_SUBDIRECTORY(3rdparty/sparkle-glue)
 ENDIF()
 
 IF(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/edbee-lib/CMakeLists.txt")
-  MESSAGE(STATUS "git submodule for required edbee-lib editor widget missing from source code, executing 'git submodule update --init' in ${CMAKE_HOME_DIRECTORY} to get it...")
-  EXECUTE_PROCESS(TIMEOUT 30
-    WORKING_DIRECTORY "${CMAKE_HOME_DIRECTORY}"
-    COMMAND git submodule update --init )
+  # The above CMakeList.txt is the top level one - we actually use the one
+  # another level down in 3rdparty/edbee-lib/edbee-lib/CMakeLists.txt
+  MESSAGE(STATUS "git submodule for required edbee-lib editor widget missing from source code, will attempt to get it...")
+  EXECUTE_PROCESS(COMMAND git submodule update --init 3rdparty/edbee-lib
+    TIMEOUT 30
+    WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+    OUTPUT_VARIABLE output_text
+    ERROR_VARIABLE error_text)
+  IF(output_text OR error_text)
+    MESSAGE(STATUS ${output_text} ${error_text})
+  ENDIF()
+ENDIF()
+
+IF(WITH_UPDATER)
+  IF(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/dblsqd/CMakeLists.txt")
+    MESSAGE(STATUS "git submodule for optional but wanted DBLSQD updater missing from source code, will attempt to get it...")
+    EXECUTE_PROCESS(COMMAND git submodule update --init 3rdparty/dblsqd
+      TIMEOUT 30
+      WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+      OUTPUT_VARIABLE output_text
+      ERROR_VARIABLE error_text)
+    IF(output_text OR error_text)
+      MESSAGE(STATUS ${output_text} ${error_text})
+    ENDIF()
+  ENDIF()
+ENDIF()
+
+IF(APPLE)
+  IF(WITH_UPDATER)
+    IF(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/sparkle-glue/CMakeLists.txt")
+      MESSAGE(STATUS "git submodule for optional but wanted Sparkle glue for updater missing from source code, will attempt to get it...")
+      EXECUTE_PROCESS(COMMAND git submodule update --init 3rdparty/sparkle-glue
+        TIMEOUT 30
+        WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+        OUTPUT_VARIABLE output_text
+        ERROR_VARIABLE error_text)
+      IF(output_text OR error_text)
+        MESSAGE(STATUS ${output_text} ${error_text})
+      ENDIF()
+    ENDIF()
+  ENDIF()
 ENDIF()
 
 IF(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/edbee-lib/CMakeLists.txt")
@@ -91,4 +134,31 @@ ELSEIF()
   MESSAGE(FATAL_ERROR "Cannot locate edbee-lib editor widget submodule source code, build abandoned!")
 ENDIF()
 
+IF(WITH_UPDATER)
+  IF(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/dblsqd/CMakeLists.txt")
+    ADD_SUBDIRECTORY(3rdparty/dblsqd)
+    ADD_DEFINITIONS(-DINCLUDE_UPDATER)
+  ELSE()
+    MESSAGE(FATAL_ERROR "Cannot locate DBLSQD updater submodule source code, build abandoned!")
+  ENDIF()
+
+  IF(APPLE)
+    IF(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/sparkle-glue/CMakeLists.txt")
+      ADD_SUBDIRECTORY(3rdparty/sparkle-glue)
+    ELSE()
+      MESSAGE(FATAL_ERROR "Cannot locate Sparkle glue for updater submodule source code, build abandoned!")
+    ENDIF()
+  ENDIF()
+ENDIF()
+
+IF(APPLE AND WITH_UPDATER AND NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/cocoapods/Pods/Sparkle")
+  MESSAGE(STATUS "Sparkle CocoaPod is missing, running 'pod install' to get it...")
+  EXECUTE_PROCESS(TIMEOUT 30
+    WORKING_DIRECTORY "${CMAKE_HOME_DIRECTORY}/3rdparty/cocoapods"
+    COMMAND pod install )
+  # TODO: Find a way to remove Sparkle cocoa pod if not needed - perhaps "pod deintegrate" ?
+ENDIF()
+
 ADD_SUBDIRECTORY(src)
+ADD_SUBDIRECTORY(3rdparty/communi)
+ADD_SUBDIRECTORY(3rdparty/lua_yajl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,6 @@ SET(mudlet_SRCS
     XMLexport.cpp
     XMLimport.cpp
     ircmessageformatter.cpp
-    updater.cpp
 )
 
 # This is for compiled UI files, not those used at runtime though the resource file.
@@ -160,8 +159,6 @@ SET(mudlet_MOC_HDRS
     TTextEdit.h
     TToolBar.h
     TTreeWidget.h
-    updater.h
-
 )
 
 SET(mudlet_HDRS
@@ -170,6 +167,7 @@ SET(mudlet_HDRS
     FontManager.h
     Host.h
     HostManager.h
+    ircmessageformatter.h
     KeyUnit.h
     LuaInterface.h
     pre_guard.h
@@ -200,9 +198,12 @@ SET(mudlet_HDRS
     VarUnit.h
     XMLexport.h
     XMLimport.h
-    ircmessageformatter.h
-    updater.h
 )
+
+IF(WITH_UPDATER)
+  LIST(APPEND mudlet_SRCS updater.cpp)
+  LIST(APPEND mudlet_MOC_HDRS updater.h)
+ENDIF(WITH_UPDATER)
 
 IF(MSVC)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -MP") # parallel builds
@@ -278,7 +279,7 @@ ENDIF()
 # Break each step into a separate command so any status message is output straight away
 IF(APPLE)
   # The include directory setup for Zip is unusual in that as well as e.g. /usr/include/zip.h
-  # we need the path to an interal header zipconf.g that it calls for using '<''>'s
+  # we need the path to an interal header zipconf.h that it calls for using '<''>'s
   # i.e. SYSTEM #include delimiters which are typically located at e.g. /usr/lib/libzip/include/zipconf.h
   # and using pkg-config is the recommended way to get the details.
   # Spotted recommendation to use pkg-config here https://github.com/Homebrew/homebrew/issues/13390
@@ -331,6 +332,14 @@ ELSE()
   message(STATUS "Qt version: ${Qt5Core_VERSION}")
 ENDIF()
 
+MESSAGE(STATUS "Using ${CMAKE_CXX_COMPILER_ID} compiler")
+
+IF(WITH_UPDATER)
+  MESSAGE(STATUS "Updater code is enabled in this configuration")
+ELSE()
+  MESSAGE(STATUS "Updater code is not enabled or not available in this configuration")
+ENDIF()
+
 FIND_PACKAGE(Qt5Multimedia REQUIRED)
 FIND_PACKAGE(Qt5Network REQUIRED)
 FIND_PACKAGE(Qt5OpenGL REQUIRED)
@@ -380,10 +389,6 @@ ENDIF(UNIX)
 # platform-specific value. If LUA_DEFAULT_DIR is unset, the root directory
 # will be used.
 ADD_DEFINITIONS(-DLUA_DEFAULT_PATH="${LUA_DEFAULT_DIR}")
-
-# Enable the built-in updater by default. Linux packagers will find it useful to disable it
-# since package managers are responsible for updates there
-ADD_DEFINITIONS(-DINCLUDE_UPDATER)
 
 # Enable leak detection for MSVC debug builds.
 if(MSVC)
@@ -449,8 +454,12 @@ TARGET_LINK_LIBRARIES(mudlet
     communi
     lua_yajl
     edbee-lib
-    dblsqd
 )
+
+IF(WITH_UPDATER)
+    TARGET_LINK_LIBRARIES(mudlet
+        dblsqd)
+ENDIF(WITH_UPDATER)
 
 IF(Qt5Gamepad_FOUND)
     TARGET_LINK_LIBRARIES(mudlet ${Qt5Gamepad_LIBRARIES})
@@ -463,19 +472,17 @@ ELSE()
 ENDIF()
 
 IF(APPLE)
-  IF(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/cocoapods/Pods/Sparkle")
-    MESSAGE(STATUS "Sparkle CocoaPod is missing, running 'pod install' to get it...")
-    EXECUTE_PROCESS(TIMEOUT 30
-            WORKING_DIRECTORY "${CMAKE_HOME_DIRECTORY}/3rdparty/cocoapods"
-            COMMAND pod install )
-  ENDIF()
-
   target_link_libraries(mudlet
           luazip
+  )
+
+  IF(WITH_UPDATER)
+    target_link_libraries(mudlet
           cocoa-qt-glue
           "-framework Sparkle"
           "-framework AppKit"
           "-F${CMAKE_HOME_DIRECTORY}/3rdparty/cocoapods/Pods/Sparkle")
+  ENDIF()
 ENDIF()
 
 IF(PC_HUNSPELL_FOUND)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -449,7 +449,7 @@ void dlgProfilePreferences::loadSpecialSettingsTab()
 #if !defined(INCLUDE_UPDATER)
     groupBox_updates->hide();
 #else
-    if (mudlet::self()->onDevelopmentVersion()) {
+    if (mudlet::scmIsDevelopmentVersion) {
         // tick the box and make it be untickable as automatic updates are disabled in dev builds
         checkbox_noAutomaticUpdates->setChecked(true);
         checkbox_noAutomaticUpdates->setDisabled(true);
@@ -1318,7 +1318,9 @@ void dlgProfilePreferences::slot_save_and_exit()
     pHost->mEnableMSDP = mEnableMSDP->isChecked();
     pHost->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
 
+#if defined(INCLUDE_UPDATER)
     mudlet::self()->updater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
+#endif
 
     if (pHost->mpMap && pHost->mpMap->mpMapper) {
         pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -121,6 +121,7 @@ QPointer<TConsole> mudlet::mpDebugConsole = nullptr;
 QMainWindow* mudlet::mpDebugArea = nullptr;
 bool mudlet::debugMode = false;
 static const QString timeFormat = "hh:mm:ss";
+const bool mudlet::scmIsDevelopmentVersion = ! QByteArray(APP_BUILD).isEmpty();
 
 QPointer<mudlet> mudlet::_self;
 
@@ -3338,13 +3339,6 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
         return QStringLiteral("%1/.config/mudlet/moduleBackups/")
                 .arg(QDir::homePath());
     }
-}
-
-// returns whenever this is a release or development build of Mudlet
-bool mudlet::onDevelopmentVersion()
-{
-    auto devSuffix = QByteArray(APP_BUILD).trimmed();
-    return !devSuffix.isEmpty();
 }
 
 #if defined(INCLUDE_UPDATER)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -181,7 +181,7 @@ public:
     bool deselect(Host* pHost, const QString& name);
     void stopSounds();
     void playSound(QString s, int);
-    bool onDevelopmentVersion();
+    static const bool scmIsDevelopmentVersion;
     QTime mReplayTime;
     int mReplaySpeed;
     QToolBar* mpMainToolBar;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -30,24 +30,87 @@ include(../3rdparty/communi/communi.pri)
 # Include lua_yajl (run time lua module needed)
 include(../3rdparty/lua_yajl/lua_yajl.pri)
 
-include(../3rdparty/dblsqd/dblsqd-sdk-qt.pri)
+# Enable the built-in updater by default - provided NO_INCLUDE_UPDATER has not
+# been previously defined (to something other than an empty string) in the
+# environment. Linux packagers will find it useful to not have the updater code
+# by using one of:
+# * NO_INCLUDE_UPDATER="true" sh -c 'qmake -spec linux-g++ ../src'
+# * NO_INCLUDE_UPDATER="true" sh -c 'qmake -spec linux-clang ../src'
+# or similar as appropriate (unless they export NO_INCLUDE_UPDATER into the
+# environment) as their qmake invocation. This is because package managers will
+# want to be responsible for updates for their distributions; similarly we also
+# disable it on FreeBSD and Cygwin as those platforms (if they ever are
+# finished) will have an external system package system to do updates.
+
+# Humm, seems that using the presence or absence of Environmental variables is
+# a bit iffy in qmake - it looks as though it is necessary to drop them into a
+# qmake variable and check that for emptiness:
+INT_NO_INCLUDE_UPDATER = $$(NO_INCLUDE_UPDATER)
+if(!isEmpty(INT_NO_INCLUDE_UPDATER))|freebsd|cygwin {
+    message("Updater code is not enabled or not available in this configuration")
+} else {
+    message("Updater code is enabled in this configuration")
+    DEFINES+=INCLUDE_UPDATER
+}
 
 # Include luazip module (run time lua module - but not needed on Linux/Windows as
 # is available prebuilt for THOSE platforms!
-macx: {
+macx {
     include(../3rdparty/luazip/luazip.pri)
 }
 
+# Define but leave this variable empty
+GIT_MODULES_NEEDED =
+
+# Check for wanted/needed submodules:
 !exists("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri") {
-    message("git submodule for required edbee-lib editor widget missing from source code, executing 'git submodule update --init' to get it...")
-    system("git submodule update --init");
+    message("git submodule for required edbee-lib editor widget missing from source code, will need to execute 'git submodule update --init' to get it...")
+    GIT_MODULES_NEEDED+="../3rdparty/edbee-lib"
+}
+
+contains(DEFINES, INCLUDE_UPDATER) {
+    !exists("../3rdparty/dblsqd/dblsqd-sdk-qt.pri") {
+        message("git submodule for optional and wanted DBLSQD updater missing from source code, will need to execute 'git submodule update --init' to get it...")
+        GIT_MODULES_NEEDED+="../3rdparty/dblsqd"
+    }
+
+    macx {
+        !exists("../3rdparty/sparkle-glue/mixing-cocoa-and-qt.pro") {
+            message("git submodule for optional and wanted Sparkle framework missing from source code, will need to execute 'git submodule update --init' to get it...")
+            GIT_MODULES_NEEDED+="../3rdparty/sparkle-glue"
+         }
+    }
+}
+
+# Now handle any submodule missing:
+isEmpty(GIT_MODULES_NEEDED) {
+    message("All git submodules needed already in place ")
+} else {
+    message("Running git submodule update --init \"$${GIT_MODULES_NEEDED}\" ")
+    system("git submodule update --init $${GIT_MODULES_NEEDED} ")
 }
 
 exists("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri") {
     # Include shiny, new (and quite substantial) editor widget
-    include("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri");
+    include("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri")
 } else {
     error("Cannot locate edbee-lib editor widget submodule source code, build abandoned!")
+}
+
+contains(DEFINES, INCLUDE_UPDATER) {
+    exists("../3rdparty/dblsqd/dblsqd-sdk-qt.pri") {
+        include("../3rdparty/dblsqd/dblsqd-sdk-qt.pri")
+    } else {
+        error("Cannot locate DBLSQD updater submodule source code, build abandoned!")
+    }
+
+    macx {
+        exists("../3rdparty/sparkle-glue/mixing-cocoa-and-qt.pro") {
+            include("../3rdparty/sparkle-glue/mixing-cocoa-and-qt.pro")
+        } else {
+            error("Cannot locate the Sparkle glue (needed for the updater) as a submodule, build abandoned!")
+        }
+    }
 }
 
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
@@ -167,7 +230,7 @@ unix:!macx {
         -lzip \
         -lz
     LUA_DEFAULT_DIR = $${DATADIR}/lua
-} else:win32: {
+} else:win32 {
     LIBS += -L"C:\\mingw32\\bin" \
         -L"C:\\mingw32\\lib" \
         -llua51 \
@@ -220,10 +283,6 @@ macx:LIBS += \
 # platform-specific value. If LUA_DEFAULT_DIR is unset, the root directory
 # will be used.
 DEFINES += LUA_DEFAULT_PATH=\\\"$${LUA_DEFAULT_DIR}\\\"
-
-# Enable the built-in updater by default. Linux packagers will find it useful to disable it
-# since package managers are responsible for updates there
-DEFINES += INCLUDE_UPDATER
 
 SOURCES += \
     ActionUnit.cpp \
@@ -294,8 +353,9 @@ SOURCES += \
     TVar.cpp \
     VarUnit.cpp \
     XMLexport.cpp \
-    XMLimport.cpp \
-    updater.cpp
+    XMLimport.cpp
+
+contains(DEFINES, INCLUDE_UPDATER) : SOURCES += updater.cpp
 
 
 HEADERS += \
@@ -372,8 +432,10 @@ HEADERS += \
     TVar.h \
     VarUnit.h \
     XMLexport.h \
-    XMLimport.h \
-    updater.h
+    XMLimport.h
+
+contains(DEFINES, INCLUDE_UPDATER) : HEADERS += updater.h
+
 
 # This is for compiled UI files, not those used at runtime through the resource file.
 FORMS += \
@@ -459,7 +521,7 @@ LUA_GEYSER.files = \
     $${PWD}/mudlet-lua/lua/geyser/GeyserWindow.lua
 LUA_GEYSER.depends = mudlet
 
-macx: {
+macx {
     # Copy mudlet-lua into the .app bundle
     # the location is relative to src.pro, so just use mudlet-lua
     APP_MUDLET_LUA_FILES.files = mudlet-lua en_US.aff en_US.dic
@@ -471,40 +533,44 @@ macx: {
 
     LIBS += -framework AppKit
 
-    # allow linker to find sparkle framework as we bundle it in
-    SPARKLE_PATH = $$PWD/../3rdparty/cocoapods/Pods/Sparkle
+    contains(DEFINES, INCLUDE_UPDATER) {
+        # allow linker to find sparkle framework as we bundle it in
+        SPARKLE_PATH = $$PWD/../3rdparty/cocoapods/Pods/Sparkle
 
-    !exists($$SPARKLE_PATH) {
-        message("Sparkle CocoaPod is missing, running 'pod install' to get it...")
-        system("cd ../3rdparty/cocoapods && pod install");
+        !exists($$SPARKLE_PATH) {
+            message("Sparkle CocoaPod is missing, running 'pod install' to get it...")
+            system("cd ../3rdparty/cocoapods && pod install")
+        }
+
+        LIBS += -F$$SPARKLE_PATH
+        LIBS += -framework Sparkle
+
+        # necessary for Sparkle to compile
+        QMAKE_LFLAGS += -F $$SPARKLE_PATH
+        QMAKE_OBJECTIVE_CFLAGS += -F $$SPARKLE_PATH
+
+        SOURCES += ../3rdparty/sparkle-glue/AutoUpdater.cpp
+
+        OBJECTIVE_SOURCES += \
+            ../3rdparty/sparkle-glue/SparkleAutoUpdater.mm \
+            ../3rdparty/sparkle-glue/CocoaInitializer.mm
+
+        HEADERS += \
+            ../3rdparty/sparkle-glue/AutoUpdater.h \
+            ../3rdparty/sparkle-glue/SparkleAutoUpdater.h \
+            ../3rdparty/sparkle-glue/CocoaInitializer.h
+
+        # Copy Sparkle into the app bundle
+        sparkle.path = Contents/Frameworks
+        sparkle.files = $$SPARKLE_PATH/Sparkle.framework
+        QMAKE_BUNDLE_DATA += sparkle
     }
-
-    LIBS += -F$$SPARKLE_PATH
-    LIBS += -framework Sparkle
-
-    # necessary for Sparkle to compile
-    QMAKE_LFLAGS += -F $$SPARKLE_PATH
-    QMAKE_OBJECTIVE_CFLAGS += -F $$SPARKLE_PATH
-
-    SOURCES += ../3rdparty/sparkle-glue/AutoUpdater.cpp
-
-    OBJECTIVE_SOURCES += ../3rdparty/sparkle-glue/SparkleAutoUpdater.mm \
-        ../3rdparty/sparkle-glue/CocoaInitializer.mm
-
-    HEADERS += ../3rdparty/sparkle-glue/AutoUpdater.h \
-        ../3rdparty/sparkle-glue/SparkleAutoUpdater.h \
-        ../3rdparty/sparkle-glue/CocoaInitializer.h
-
-    # Copy Sparkle into the app bundle
-    sparkle.path = Contents/Frameworks
-    sparkle.files = $$SPARKLE_PATH/Sparkle.framework
-    QMAKE_BUNDLE_DATA += sparkle
 
     # And add frameworks to the rpath so that the app can find the framework.
     QMAKE_RPATHDIR += @executable_path/../Frameworks
 }
 
-win32: {
+win32 {
     # set the Windows binary icon
     RC_ICONS = icons/mudlet_main_512x512_6XS_icon.ico
 
@@ -529,7 +595,7 @@ OTHER_FILES += \
 # lua file installation, needs install, sudo, and a setting in /etc/sudo.conf
 # or via enviromental variable SUDO_ASKPASS to something like ssh-askpass
 # to provide a graphic password requestor needed to install software
-unix:!macx: {
+unix:!macx {
 # say what we want to get installed by "make install" (executed by 'deployment' step):
     INSTALLS += \
         target \
@@ -538,6 +604,7 @@ unix:!macx: {
 }
 
 DISTFILES += \
+    ../.gitmodules \
     ../.travis.yml \
     ../CMakeLists.txt \
     ../CI/travis.before_install.sh \

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -121,7 +121,7 @@ void Updater::setupOnWindows()
 
     // Setup to automatically download the new release when an update is available
     QObject::connect(feed, &dblsqd::Feed::ready, [=]() {
-        if (!updateAutomatically() || mudlet::self()->onDevelopmentVersion()) {
+        if (mudlet::scmIsDevelopmentVersion || !updateAutomatically()) {
             return;
         }
 
@@ -183,7 +183,7 @@ void Updater::setupOnLinux()
 
         // only update release builds to prevent auto-update from overwriting your
         // compiled binary while in development
-        if (!updateAutomatically() || mudlet::self()->onDevelopmentVersion()) {
+        if (mudlet::scmIsDevelopmentVersion || !updateAutomatically()) {
             return;
         }
 

--- a/src/updater.h
+++ b/src/updater.h
@@ -58,16 +58,17 @@ private:
 #elif defined(Q_OS_WIN)
     void setupOnWindows();
     void prepareSetupOnWindows(const QString& fileName);
+#elif defined(Q_OS_MACOS)
+    void setupOnMacOS();
 #endif
 
     void recordUpdateTime() const;
     void finishSetup();
 
-#if defined(Q_OS_MACOS)
-    AutoUpdater* msparkleUpdater;
-    void setupOnMacOS();
-#elif defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX)
     QString unzippedBinaryName;
+#elif defined(Q_OS_MACOS)
+    AutoUpdater* msparkleUpdater;
 #endif
 
 


### PR DESCRIPTION
Correct compilation failure when `INCLUDE_UPDATER` is NOT defined in `(void) dlgProfilePreferences::slot_save_and_exit()`

Correct previous qmake / cmake project files which no longer behave as required as there is now more than one git sub-module.  Also allows command line building to suppress the effects of the `INCLUDE_UPDATER` compiler `#define` value by specifying an environment variable `NO_INCLUDE_UPDATER` to a non-empty string (or a number) before the relevant (makefile) building command is run, typically this would be from the parallel build directory:
* For qmake (gcc): `NO_INCLUDE_UPDATER="string" sh -c 'qmake -spec linux-g++ ../src/'`
  or qmake (clang): `NO_INCLUDE_UPDATER="string" sh -c 'qmake -spec linux-clang++ ../src/'`
* For cmake (gcc): `NO_INCLUDE_UPDATER="string" CC=/usr/bin/gcc CXX=/usr/bin/g++ cmake ..`
  or cmake (clang): `NO_INCLUDE_UPDATER="string" CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake ..`

cmake will read the environment from the command line but qmake (possibly because on my system it could be invoked via a symbolic link or a shell wrapper) does not seem to notice environment settings preceding it...?!

Change `(bool) mudlet::self()->onDevelopmentVersion()` function into a `(const static bool) mudlet::scmIsDevelopmentVersion` value which is faster and more compact IMVHO.

Add `.gitmodules` to files visible in Qt Creator as it is not something that ought to be overlooked.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>