### PR TITLE
Revise: add SIL Open Font licence to "About Mudlet" dialogue

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -638,6 +638,77 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
                                "ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR "
                                "INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT "
                                "SOFTWARE.</p>"));
+
+    QString SILOpenFontText(
+                QStringLiteral("<h3>SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007</h3>"
+                               "<p>PREAMBLE</p>"
+                               "<p>The goals of the Open Font License (OFL) are to stimulate worldwide "
+                               "development of collaborative font projects, to support the font "
+                               "creation efforts of academic and linguistic communities, and to "
+                               "provide a free and open framework in which fonts may be shared and "
+                               "improved in partnership with others.</p>"
+                               "<p>The OFL allows the licensed fonts to be used, studied, modified and "
+                               "redistributed freely as long as they are not sold by themselves. The "
+                               "fonts, including any derivative works, can be bundled, embedded, "
+                               "redistributed and/or sold with any software provided that any reserved "
+                               "names are not used by derivative works. The fonts and derivatives, "
+                               "however, cannot be released under any other type of license. The "
+                               "requirement for fonts to remain under this license does not apply to "
+                               "any document created using the fonts or their derivatives.</p>"
+                               "<p>DEFINITIONS</p>"
+                               "<p>&quot;Font Software&quot; refers to the set of files released by the "
+                               "Copyright Holder(s) under this licence and clearly marked as such. This may "
+                               "include source files, build scripts and documentation.</p>"
+                               "<p>&quot;Reserved Font Name&quot; refers to any names specified as such "
+                               "after the copyright statement(s).</p>"
+                               "<p>&quot;Original Version&quot; refers to the collection of Font Software "
+                               "components as distributed by the Copyright Holder(s).</p>"
+                               "<p>&quot;Modified Version&quot; refers to any derivative made by adding to, "
+                               "deleting, or substituting -- in part or in whole -- any of the components of "
+                               "the Original Version, by changing formats or by porting the Font Software to a "
+                               "new environment.</p>"
+                               "<p>&quot;Author(s)&quot; refers to any designer, engineer, programmer, technical "
+                               "writer or other person who contributed to the Font Software.</p>"
+                               "<p>PERMISSION &amp; CONDITIONS</p>"
+                               "<p>Permission is hereby granted, free of charge, to any person obtaining "
+                               "a copy of the Font Software, to use, study, copy, merge, embed, "
+                               "modify, redistribute, and sell modified and unmodified copies of the "
+                               "Font Software, subject to the following conditions:"
+                               "<ol style=\"1\"><li> Neither the Font Software nor any of its individual components, "
+                               "in Original or Modified Versions, may be sold by itself.</li>"
+                               "<li>Original or Modified Versions of the Font Software may be bundled, "
+                               "redistributed and/or sold with any software, provided that each copy "
+                               "contains the above copyright notice and this license. These can be "
+                               "included either as stand-alone text files, human-readable headers or "
+                               "in the appropriate machine-readable metadata fields within text or "
+                               "binary files as long as those fields can be easily viewed by the user.</li>"
+                               "<li>No Modified Version of the Font Software may use the Reserved Font "
+                               "Name(s) unless explicit written permission is granted by the "
+                               "corresponding Copyright Holder. This restriction only applies to the "
+                               "primary font name as presented to the users.</li>"
+                               "<li>The name(s) of the Copyright Holder(s) or the Author(s) of the Font "
+                               "Software shall not be used to promote, endorse or advertise any "
+                               "Modified Version, except to acknowledge the contribution(s) of the "
+                               "Copyright Holder(s) and the Author(s) or with their explicit written "
+                               "permission.</li>"
+                               "<li>The Font Software, modified or unmodified, in part or in whole, "
+                               "must be distributed entirely under this license, and must not be "
+                               "distributed under any other license. The requirement for fonts to "
+                               "remain under this license does not apply to any document created using "
+                               "the Font Software</p>"
+                               "<p>TERMINATION</li></ol>"
+                               "<p>This licence becomes null and void if any of the above conditions are not "
+                               "met.</p>"
+                               "<p>DISCLAIMER</p>"
+                               "<p>THE FONT SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY "
+                               "KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF "
+                               "MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF "
+                               "COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT "
+                               "HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY "
+                               "GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN "
+                               "ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR "
+                               "INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT "
+                               "SOFTWARE.</p>"));
 #endif
 
     QString communiHeader(tr("<h2><u>Communi IRC Library</u></h2>"
@@ -792,13 +863,16 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 #if defined(INCLUDE_FONTS) || defined(DEBUG_SHOWALL)
     license_3rdParty_texts.append(QStringLiteral("<hr>%31")
                                   .arg(UbuntuFontText));               // 31 - Ubuntu Font Text - not translatable
+    license_3rdParty_texts.append(QStringLiteral("<hr>%32")
+                                  .arg(SILOpenFontText));              // 32 - SIL Open Font Text - not translatable
+
 #endif
 
     license_3rdParty_texts.append(QStringLiteral("<hr><br>"
                                                  "<center><img src=\":/icons/Discord-Logo+Wordmark-Color_400x136px.png\"/></center><br>"
-                                                 "%32%33")
-                                  .arg(DiscordHeader,                  // 32 - Discord header - translatable
-                                       MIT_Body));                     // 33 - Discord body MIT - not translatable
+                                                 "%33%34")
+                                  .arg(DiscordHeader,                  // 33 - Discord header - translatable
+                                       MIT_Body));                     // 34 - Discord body MIT - not translatable
 
     license_3rdParty_texts.append(QStringLiteral("</body></html>"));
 


### PR DESCRIPTION
The text is quite similar to the Ubuntu Font licence as it happens and it is now needed under exactly the same situation (when `INCLUDE_FONTS` is `#define`d during compilation...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>