### PR TITLE
Fix copy as image for chinese

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1120,7 +1120,7 @@ void TConsole::changeColors()
         const QString t = "123";
         p.drawText(r, 1, t, &r2);
         // N/U:        int mFontHeight = QFontMetrics( mDisplayFont ).height();
-        int mFontWidth = QFontMetrics(mDisplayFont).width(QChar('W'));
+        int mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         auto letterSpacing = static_cast<qreal>(mFontWidth - static_cast<qreal>(r2.width() / t.size()));
         mUpperPane->mLetterSpacing = letterSpacing;
         mLowerPane->mLetterSpacing = letterSpacing;
@@ -1166,7 +1166,7 @@ void TConsole::changeColors()
         const QString t = "123";
         p.drawText(r, 1, t, &r2);
         // N/U:        int mFontHeight = QFontMetrics( mpHost->mDisplayFont ).height();
-        int mFontWidth = QFontMetrics(mpHost->mDisplayFont).width(QChar('W'));
+        int mFontWidth = QFontMetrics(mpHost->mDisplayFont).averageCharWidth();
         auto letterSpacing = static_cast<qreal>(mFontWidth - static_cast<qreal>(r2.width() / t.size()));
         mUpperPane->mLetterSpacing = letterSpacing;
         mLowerPane->mLetterSpacing = letterSpacing;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6198,7 +6198,7 @@ int TLuaInterpreter::getNetworkLatency(lua_State* L)
 int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int fw = QFontMetrics(host.mDisplayFont).width("W");
+    int fw = QFontMetrics(host.mDisplayFont).averageCharWidth();
     fw *= host.mWrapAt + 1;
     lua_pushnumber(L, fw);
     return 1;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -69,7 +69,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
     mLastClickTimer.start();
     if (pC->getType() != TConsole::CentralDebugConsole) {
         mFontHeight = QFontMetrics(mpHost->mDisplayFont).height();
-        mFontWidth = QFontMetrics(mpHost->mDisplayFont).width(QChar('W'));
+        mFontWidth = QFontMetrics(mpHost->mDisplayFont).averageCharWidth();
         mScreenWidth = 100;
         if ((width() / mFontWidth) < mScreenWidth) {
             mScreenWidth = 100; //width()/mFontWidth;
@@ -92,7 +92,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
         // This is part of the Central Debug Console
         mShowTimeStamps = true;
         mFontHeight = QFontMetrics(mDisplayFont).height();
-        mFontWidth = QFontMetrics(mDisplayFont).width(QChar('W'));
+        mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         mScreenWidth = 100;
         mDisplayFont.setFixedPitch(true);
 #if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
@@ -225,7 +225,7 @@ void TTextEdit::initDefaultSettings()
 void TTextEdit::updateScreenView()
 {
     if (isHidden()) {
-        mFontWidth = QFontMetrics(mDisplayFont).width(QChar(' '));
+        mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         mFontDescent = QFontMetrics(mDisplayFont).descent();
         mFontAscent = QFontMetrics(mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;
@@ -249,7 +249,7 @@ void TTextEdit::updateScreenView()
     // This was "if (pC->mType == TConsole::MainConsole) {"
     // and mIsMiniConsole is true for user created Mini Consoles and User Windows
     if (mpConsole->getType() == TConsole::MainConsole) {
-        mFontWidth = QFontMetrics(mpHost->mDisplayFont).width(QChar('W'));
+        mFontWidth = QFontMetrics(mpHost->mDisplayFont).averageCharWidth();
         mFontDescent = QFontMetrics(mpHost->mDisplayFont).descent();
         mFontAscent = QFontMetrics(mpHost->mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;
@@ -270,7 +270,7 @@ void TTextEdit::updateScreenView()
         }
 #endif
     } else {
-        mFontWidth = QFontMetrics(mDisplayFont).width(QChar('W'));
+        mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         mFontDescent = QFontMetrics(mDisplayFont).descent();
         mFontAscent = QFontMetrics(mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1489,13 +1489,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
     for (int y = mPA.y(), total = mPB.y() + 1; y < total; ++y) {
         const QString lineText{mpBuffer->lineBuffer.at(y)};
         // Will accumulate the width in pixels of the current line:
-        int lineWidth{};
-        if (mShowTimeStamps) {
-            // The timestamp is (currently) 13 "normal width" characters
-            // but that might not always be the case in some future I18n
-            // situations:
-            lineWidth += 13 * mFontWidth;
-        }
+        int lineWidth{(mShowTimeStamps ? 13 : 0) * mFontWidth};
         // Accumulated width in "normal" width characters:
         int column{};
         QTextBoundaryFinder boundaryFinder(QTextBoundaryFinder::Grapheme, lineText);
@@ -1511,7 +1505,10 @@ void TTextEdit::slot_copySelectionToClipboardImage()
                 charWidth = getGraphemeWidth(unicode);
             }
             column +=charWidth;
-            lineWidth = charWidth * mFontWidth;
+            // The timestamp is (currently) 13 "normal width" characters
+            // but that might not always be the case in some future I18n
+            // situations:
+            lineWidth = (mShowTimeStamps ? 13 + column : column) * mFontWidth;
             // Increment for loop:
             indexOfChar = nextBoundary;
         }
@@ -1519,7 +1516,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
         largestLine = std::max(lineWidth, largestLine);
     }
 
-    auto widthpx = qMin(65500, largestLine * mFontWidth);
+    auto widthpx = qMin(65500, largestLine);
 
     auto rect = QRect(mPA.x(), mPA.y(), widthpx, heightpx);
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -996,6 +996,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
 // caller(s):
 int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber) const
 {
+#if defined (QT_DEBUG)
+    // Enable this from debugger to show output
+    static bool debug_mousePositionInLine = false;
+#endif
+
     if (lineNumber >= 0 && lineNumber < mpBuffer->lineBuffer.size()) {
         // Line number is (should be) within range of lines in the
         // TBuffer::lineBuffer - might need to check that this still works after
@@ -1011,12 +1016,27 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber) co
         int currentX = 0;
         QString lineText = mpBuffer->lineBuffer.at(lineNumber);
         QTextBoundaryFinder boundaryFinder(QTextBoundaryFinder::Grapheme, lineText);
-        qDebug().noquote().nospace() << "TTextEdit::convertMouseXToBufferX(" << mouseX << ", " << lineNumber << ") INFO - finding mouse click position in line:";
+#if defined (QT_DEBUG)
+        if (debug_mousePositionInLine) {
+            qDebug().noquote().nospace() << "TTextEdit::convertMouseXToBufferX(" << mouseX << ", " << lineNumber << ") INFO - finding mouse click position in line:";
+        }
+#endif
         for (int indexOfChar = 0, total = lineText.size(); indexOfChar < total; /*incrementing is done inside loop*/) {
             int nextBoundary = boundaryFinder.toNextBoundary();
             // Width in "normal" width equivalent of this grapheme:
             int charWidth = 0;
             const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
+#if defined (QT_DEBUG)
+            if (debug_mousePositionInLine) {
+                if (indexOfChar > 0) {
+                    // Include graphemes BEFORE the current last one considered:
+                    qDebug().noquote().nospace() << lineText.left(indexOfChar) << "»" << grapheme << "«";
+                } else {
+                    // First grapheme:
+                    qDebug().noquote().nospace() << "»" << grapheme << "«";
+                }
+            }
+#endif
             const uint unicode = getGraphemeBaseCharacter(grapheme);
             if (unicode == '\t') {
                 charWidth = mTabStopwidth - (column % mTabStopwidth);


### PR DESCRIPTION
This is a collection of 5 commits that better handles the text that makes up each line of text in the `TBuffer::lineBuffer` specifically they iterate through the text on a grapheme by grapheme basis and considered the effective width of the glyphs from the passing of the **first** Unicode codepoint of the grapheme into the `getGraphemeWidth(ucs4)` method.  This means that non-BMP characters and combining diacriticals are now correctly accounted for - and stops the production of:
```
"TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which is unprintable, codepoint number: U+xxxx"
```
error messages when the individual surrogates were previously pushed into that method and:
```
"TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which is a zero width combiner, codepoint number: U+xxxx"
```
when combining diacriticals were so pushed...!

It also switches to using `QFontMetrics::averageCharWidth()` instead of trying to measure the width of semi-randomly chosen `QChars` i.e. space and 'W' with `QFontMetrics::width(QChar)` which has been declared ***obsolete*** and returns a potentially seg. faulting `0` in some situations that we *have* been encountering - see #2391 .