### PR TITLE
Fix copy as image for chinese 2

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -698,6 +698,9 @@ TChar::TChar(const TChar& copy)
 {
 }
 
+const QString timeStampFormat = QStringLiteral("hh:mm:ss.zzz ");
+const QString blankTimeStamp  = QStringLiteral("------------ ");
+
 TBuffer::TBuffer(Host* pH)
 : mLinkID(0)
 , mLinesLimit(10000)
@@ -1640,7 +1643,7 @@ COMMIT_LINE:
                 }
                 buffer.push_back(mMudBuffer);
                 dirty << true;
-                timeBuffer << (QTime::currentTime()).toString("hh:mm:ss.zzz") + "   ";
+                timeBuffer << QTime::currentTime().toString(timeStampFormat);
                 if (ch == '\xff') {
                     promptBuffer.append(true);
                 } else {
@@ -1658,7 +1661,7 @@ COMMIT_LINE:
                 }
                 buffer.back() = mMudBuffer;
                 dirty.back() = true;
-                timeBuffer.back() = QTime::currentTime().toString("hh:mm:ss.zzz") + "   ";
+                timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
                 if (ch == '\xff') {
                     promptBuffer.back() = true;
                 } else {
@@ -1679,7 +1682,7 @@ COMMIT_LINE:
             std::deque<TChar> newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
-            timeBuffer.push_back("   ");
+            timeBuffer.push_back(QString());
             promptBuffer << false;
             dirty << true;
             if (static_cast<int>(buffer.size()) > mLinesLimit) {
@@ -3057,7 +3060,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
-        timeBuffer << QTime::currentTime().toString(QStringLiteral("hh:mm:ss.zzz   "));
+        timeBuffer << QTime::currentTime().toString(timeStampFormat);
         promptBuffer << false;
         dirty << true;
         last = 0;
@@ -3078,7 +3081,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             std::deque<TChar> newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
-            timeBuffer << QStringLiteral("-------------");
+            timeBuffer << blankTimeStamp;
             promptBuffer << false;
             dirty << true;
             firstChar = true;
@@ -3111,7 +3114,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                     } else {
                         lineBuffer.append(QString());
                     }
-                    timeBuffer << QStringLiteral("-------------");
+                    timeBuffer << blankTimeStamp;
                     promptBuffer << false;
                     dirty << true;
                     log(size() - 2, size() - 2);
@@ -3130,7 +3133,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                 linkID);
         buffer.back().push_back(c);
         if (firstChar) {
-            timeBuffer.back() = QTime::currentTime().toString(QStringLiteral("hh:mm:ss.zzz   "));
+            timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
             firstChar = false;
         }
     }
@@ -3151,7 +3154,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
-        timeBuffer << QTime::currentTime().toString(QStringLiteral("hh:mm:ss.zzz   "));
+        timeBuffer << QTime::currentTime().toString(timeStampFormat);
         promptBuffer << false;
         dirty << true;
         last = 0;
@@ -3171,7 +3174,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             std::deque<TChar> newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
-            timeBuffer << QStringLiteral("-------------");
+            timeBuffer << blankTimeStamp;
             promptBuffer << false;
             dirty << true;
             firstChar = true;
@@ -3204,7 +3207,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                     } else {
                         lineBuffer.append(QString());
                     }
-                    timeBuffer << QStringLiteral("-------------");
+                    timeBuffer << blankTimeStamp;
                     promptBuffer << false;
                     dirty << true;
                     log(size() - 2, size() - 2);
@@ -3219,7 +3222,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
-            timeBuffer.back() = QTime::currentTime().toString(QStringLiteral("hh:mm:ss.zzz   "));
+            timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
             firstChar = false;
         }
     }
@@ -3243,7 +3246,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
-        timeBuffer << (QTime::currentTime()).toString("hh:mm:ss.zzz") + "   ";
+        timeBuffer << QTime::currentTime().toString(timeStampFormat);
         promptBuffer << false;
         dirty << true;
         lastLine = 0;
@@ -3264,7 +3267,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
-            timeBuffer.back() = (QTime::currentTime()).toString("hh:mm:ss.zzz") + "   ";
+            timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
             firstChar = false;
         }
     }
@@ -3564,7 +3567,7 @@ void TBuffer::log(int fromLine, int toLine)
             // This only handles a single line of logged text at a time:
             linesToLog << bufferToHtml(mpHost->mIsLoggingTimestamps, i);
         } else {
-            linesToLog << ((mpHost->mIsLoggingTimestamps && !timeBuffer.at(i).isEmpty()) ? timeBuffer.at(i).left(13) : QString()) % lineBuffer.at(i) % QChar::LineFeed;
+            linesToLog << ((mpHost->mIsLoggingTimestamps && !timeBuffer.at(i).isEmpty()) ? timeBuffer.at(i).left(timeStampFormat.length()) : QString()) % lineBuffer.at(i) % QChar::LineFeed;
         }
     }
 
@@ -4100,7 +4103,7 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     // we will NOT need a closing "</span>"
     if (showTimeStamp && !timeBuffer.at(row).isEmpty()) {
         // TODO: formatting according to TTextEdit.cpp: if( i2 < timeOffset ) - needs updating if we allow the colours to be user set:
-        s.append(QStringLiteral("<span style=\"color: rgb(200,150,0); background: rgb(22,22,22); \">%1").arg(timeBuffer.at(row).left(13)));
+        s.append(QStringLiteral("<span style=\"color: rgb(200,150,0); background: rgb(22,22,22); \">%1").arg(timeBuffer.at(row).left(timeStampFormat.length())));
         // Set the current idea of what the formatting is so we can spot if it
         // changes:
         currentFgColor = QColor(200,150,0);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -366,7 +366,8 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     timeStampButton->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(
         tr("Show Time Stamps.")));
     timeStampButton->setIcon(QIcon(QStringLiteral(":/icons/dialog-information.png")));
-    connect(timeStampButton, &QAbstractButton::pressed, mUpperPane, &TTextEdit::slot_toggleTimeStamps);
+    connect(timeStampButton, &QAbstractButton::toggled, mUpperPane, &TTextEdit::slot_toggleTimeStamps);
+    connect(timeStampButton, &QAbstractButton::toggled, mLowerPane, &TTextEdit::slot_toggleTimeStamps);
 
     auto replayButton = new QToolButton;
     replayButton->setCheckable(true);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10925,7 +10925,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     int s = 1;
     int n = lua_gettop(L);
     // console name is an optional first argument
-    if (n > 4) {
+    if (n >= 4) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "insertPopup: wrong argument type");
             lua_error(L);
@@ -10991,7 +10991,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
         return 1;
     }
 
-    if (a1.empty()) {
+    if (a1.empty() || a1 == "main") {
         host.mpConsole->insertLink(txt, _commandList, _hintList, customFormat);
     } else {
         mudlet::self()->insertLink(&host, name, txt, _commandList, _hintList, customFormat);
@@ -11141,7 +11141,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     int s = 1;
     int n = lua_gettop(L);
     // console name is an optional first argument
-    if (n > 4) {
+    if (n >= 4) {
         if (!lua_isstring(L, s)) {
             lua_pushfstring(L, "echoPopup: bad argument #%d type (window name as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10158,21 +10158,6 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
         return 2;
     }
 
-    // TODO: Remove this block of code once it is not needed (map file format updated to 17)
-    {
-        static bool isWarningIssued = false;
-        if (!isWarningIssued && host.mpMap->mDefaultVersion <= 16 && host.mpMap->mSaveVersion < 17) {
-            QString warnMsg = tr("[ WARN ]  - Lua command setAreaUserData() used - it is currently flagged as experimental!");
-            QString infoMsg = tr("[ INFO ]  - This feature requires a newer map format. Please change your map\n"
-                                 "format to a newer version to be able to SAVE this feature's data.\n\n"
-                                 "To avoid filling the screen up with repeated messages, this is\n"
-                                 "your only warning about this command...!");
-            host.postMessage(warnMsg);
-            host.postMessage(infoMsg);
-            isWarningIssued = true;
-        }
-    }
-
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         lua_pushnil(L);
@@ -10216,21 +10201,6 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
         return 1;
     } else {
         value = QString::fromUtf8(lua_tostring(L, 2));
-    }
-
-    // TODO: Remove this block of code once it is not needed (map file format updated to 17)
-    {
-        static bool isWarningIssued = false;
-        if (!isWarningIssued && host.mpMap->mDefaultVersion <= 16 && host.mpMap->mSaveVersion < 17) {
-            QString warnMsg = tr("[ WARN ]  - Lua command setMapUserData() used - it is currently flagged as experimental!");
-            QString infoMsg = tr("[ INFO ]  - This feature requires a newer map format. Please change your map\n"
-                                 "format to a newer version to be able to SAVE this feature's data.\n\n"
-                                 "To avoid filling the screen up with repeated messages, this is\n"
-                                 "your only warning about this command...!");
-            host.postMessage(warnMsg);
-            host.postMessage(infoMsg);
-            isWarningIssued = true;
-        }
     }
 
     host.mpMap->mUserData[key] = value;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -918,7 +918,9 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
     normaliseSelection();
     QPoint p1 = mPA - PC;
     QPoint p2 = mPB - PC;
-    if (p1.manhattanLength() < p2.manhattanLength()) {
+    if ( (abs(p1.y()) < abs(p2.y()))
+       ||((abs(p1.y()) == abs(p2.y()) && abs(p1.x()) < abs(p2.x())))) {
+
         if (mPA.y() < PC.y() || ((mPA.x() < PC.x()) && (mPA.y() == PC.y()))) {
             int y1 = PC.y();
             for (int yIndex = y1, total = mPA.y(); yIndex >= total; --yIndex) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -65,7 +65,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 , mWideAmbigousWidthGlyphs(pH->wideAmbiguousEAsianGlyphs())
 , mUseOldUnicode8(false)
 , mTabStopwidth(8)
-, mTimeStampWidth(13)
+, mTimeStampWidth(13) // Should be the same as the size of the timeStampFormat constant in the TBuffer class
 {
     mLastClickTimer.start();
     if (pC->getType() != TConsole::CentralDebugConsole) {
@@ -1059,9 +1059,7 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber) co
             }
             column +=charWidth;
             leftX = rightX;
-            // The need to add 2 seems a little odd but it does work to make the
-            // position decoding the same whether time stamps are showing or not!
-            rightX = (mShowTimeStamps ? mTimeStampWidth + column + 2 : column) * mFontWidth;
+            rightX = (mShowTimeStamps ? mTimeStampWidth + column : column) * mFontWidth;
             debugText << QStringLiteral("[%1]%2[%3]").arg(QString::number(leftX), grapheme, QString::number(rightX - 1));
             if (leftX <= mouseX && mouseX < rightX) {
                 return std::max(0, indexOfChar);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -894,16 +894,16 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
         }
 
         if (oldAY < mPA.y()) {
-            for (int y = oldAY, total = mPA.y(); y < total; ++y) {
-                for (auto& x : mpBuffer->buffer[y]) {
-                    x.deselect();
+            for (int yIndex = oldAY, total = mPA.y(); yIndex < total; ++yIndex) {
+                for (auto& TQchar : mpBuffer->buffer[yIndex]) {
+                    TQchar.deselect();
                 }
             }
         }
         if (oldBY > mPB.y()) {
-            for (int y = mPB.y() + 1; y <= oldBY; ++y) {
-                for (auto& x : mpBuffer->buffer[y]) {
-                    x.deselect();
+            for (int yIndex = mPB.y() + 1; yIndex <= oldBY; ++yIndex) {
+                for (auto& TQchar : mpBuffer->buffer[yIndex]) {
+                    TQchar.deselect();
                 }
             }
         }
@@ -921,30 +921,32 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
     if (p1.manhattanLength() < p2.manhattanLength()) {
         if (mPA.y() < PC.y() || ((mPA.x() < PC.x()) && (mPA.y() == PC.y()))) {
             int y1 = PC.y();
-            for (int y = y1, total = mPA.y(); y >= total; --y) {
-                if (y >= static_cast<int>(mpBuffer->buffer.size()) || y < 0) {
+            for (int yIndex = y1, total = mPA.y(); yIndex >= total; --yIndex) {
+                if (yIndex >= static_cast<int>(mpBuffer->buffer.size()) || yIndex < 0) {
                     break;
                 }
-                int x = mpBuffer->buffer.at(y).size() - 1;
-                if (y == y1) {
-                    x = PC.x();
-                    if (x >= static_cast<int>(mpBuffer->buffer.at(y).size())) {
-                        x = static_cast<int>(mpBuffer->buffer.at(y).size()) - 1;
+                auto& bufferLine = mpBuffer->buffer.at(yIndex);
+                int xIndex = bufferLine.size() - 1;
+                if (yIndex == y1) {
+                    xIndex = PC.x();
+                    if (xIndex >= static_cast<int>(bufferLine.size())) {
+                        xIndex = static_cast<int>(bufferLine.size()) - 1;
                     }
-                    if (x < 0) {
-                        x = 0;
+                    if (xIndex < 0) {
+                        xIndex = 0;
                     }
                 }
-                for (;; --x) {
-                    if ((y == mPA.y()) && (x < mPA.x())) {
+                for (;; --xIndex) {
+                    if ((yIndex == mPA.y()) && (xIndex < mPA.x())) {
                         break;
                     }
 
-                    if (x < static_cast<int>(mpBuffer->buffer[y].size()) && x >= 0) {
-                        if (mpBuffer->buffer.at(y).at(x).isSelected()) {
-                            mpBuffer->buffer.at(y).at(x).deselect();
-                            mpBuffer->dirty[y] = true;
+                    if (xIndex >= 0 && xIndex < static_cast<int>(mpBuffer->buffer[yIndex].size())) {
+                        if (bufferLine.at(xIndex).isSelected()) {
+                            bufferLine[xIndex].deselect();
+                            mpBuffer->dirty[yIndex] = true;
                         }
+
                     } else {
                         break;
                     }
@@ -955,22 +957,23 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
     } else {
         if (mPB.y() > PC.y() || (mPB.x() > PC.x() && mPB.y() == PC.y())) {
             int y1 = PC.y();
-            for (int y = y1, total = mPB.y(); y <= total; ++y) {
+            for (int yIndex = y1, total = mPB.y(); yIndex <= total; ++yIndex) {
                 int x = 0;
-                if (y == y1) {
+                if (yIndex == y1) {
                     x = PC.x();
                 }
-                if (y >= static_cast<int>(mpBuffer->buffer.size()) || y < 0) {
+                if (yIndex >= static_cast<int>(mpBuffer->buffer.size()) || yIndex < 0) {
                     break;
                 }
+                auto& bufferLine = mpBuffer->buffer.at(yIndex);
                 for (;; ++x) {
-                    if ((y == mPB.y()) && (x > mPB.x())) {
+                    if ((yIndex == mPB.y()) && (x > mPB.x())) {
                         break;
                     }
-                    if (x < static_cast<int>(mpBuffer->buffer.at(y).size())) {
-                        if (mpBuffer->buffer.at(y).at(x).isSelected()) {
-                            mpBuffer->buffer.at(y).at(x).deselect();
-                            mpBuffer->dirty[y] = true;
+                    if (x < static_cast<int>(bufferLine.size())) {
+                        if (bufferLine.at(x).isSelected()) {
+                            bufferLine[x].deselect();
+                            mpBuffer->dirty[yIndex] = true;
                         }
                     } else {
                         break;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -832,6 +832,13 @@ void TTextEdit::swap(QPoint& p1, QPoint& p2)
     p2 = tmp;
 }
 
+void TTextEdit::normaliseSelection()
+{
+    if (mPA.y() > mPB.y() || ((mPA.y() == mPB.y()) && (mPA.x() > mPB.x()))) {
+        swap(mPA, mPB);
+    }
+}
+
 void TTextEdit::mouseMoveEvent(QMouseEvent* event)
 {
     if (mFontWidth == 0 || mFontHeight == 0) {
@@ -907,12 +914,8 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
         highlight();
         return;
     }
-    if ((mPA.y() == mPB.y()) && (mPA.x() > mPB.x())) {
-        swap(mPA, mPB);
-    }
-    if (mPA.y() > mPB.y()) {
-        swap(mPA, mPB);
-    }
+
+    normaliseSelection();
     QPoint p1 = mPA - PC;
     QPoint p2 = mPB - PC;
     if (p1.manhattanLength() < p2.manhattanLength()) {
@@ -978,13 +981,8 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
 
         mPB = PC;
     }
-    if ((mPA.y() == mPB.y()) && (mPA.x() > mPB.x())) {
-        swap(mPA, mPB);
-    }
-    if (mPA.y() > mPB.y()) {
-        swap(mPA, mPB);
-    }
 
+    normaliseSelection();
     highlight();
 }
 
@@ -1323,12 +1321,7 @@ void TTextEdit::slot_copySelectionToClipboard()
 
 void TTextEdit::slot_copySelectionToClipboardHTML()
 {
-    if ((mPA.y() == mPB.y()) && (mPA.x() > mPB.x())) {
-        swap(mPA, mPB);
-    }
-    if (mPA.y() > mPB.y()) {
-        swap(mPA, mPB);
-    }
+    normaliseSelection();
 
     QString title;
     if (mpConsole->getType() == TConsole::CentralDebugConsole) {
@@ -1432,13 +1425,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
 
     // if selection was made backwards swap
     // right to left
-    if ((mPA.y() == mPB.y()) && (mPA.x() > mPB.x())) {
-        swap(mPA, mPB);
-    }
-    // down to up
-    if (mPA.y() > mPB.y()) {
-        swap(mPA, mPB);
-    }
+    normaliseSelection();
 
     if (mFontWidth <= 0 || mFontHeight <= 0) {
         return;
@@ -1568,13 +1555,7 @@ QString TTextEdit::getSelectedText(char newlineChar)
 
     // if selection was made backwards swap
     // right to left
-    if ((mPA.y() == mPB.y()) && (mPA.x() > mPB.x())) {
-        swap(mPA, mPB);
-    }
-    // down to up
-    if (mPA.y() > mPB.y()) {
-        swap(mPA, mPB);
-    }
+    normaliseSelection();
 
     QString text;
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -174,11 +174,13 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
 }
 
 
-void TTextEdit::slot_toggleTimeStamps()
+void TTextEdit::slot_toggleTimeStamps(const bool state)
 {
-    mShowTimeStamps = !mShowTimeStamps;
-    forceUpdate();
-    update();
+    if (mShowTimeStamps != state) {
+        mShowTimeStamps = state;
+        forceUpdate();
+        update();
+    }
 }
 
 void TTextEdit::slot_scrollBarMoved(int line)

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -172,6 +172,10 @@ private:
     // probably be 1 (so that a tab is just treated as a space), 2, 4 and 8,
     // in the past it was typically 8 and this is what we'll use at present:
     int mTabStopwidth;
+    // How many normal width characters that are used for the time stamps; it
+    // would only be valid to change this by clearing the buffer first - so
+    // making this a const value for the moment:
+    const int mTimeStampWidth;
 };
 
 #endif // MUDLET_TTEXTEDIT_H

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -110,7 +110,7 @@ public:
     qreal mLetterSpacing;
 
 public slots:
-    void slot_toggleTimeStamps();
+    void slot_toggleTimeStamps(const bool);
     void slot_copySelectionToClipboard();
     void slot_selectAll();
     void slot_scrollBarMoved(int);

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -132,6 +132,7 @@ private:
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;
     int convertMouseXToBufferX(const int mouseX, const int lineNumber) const;
     int getGraphemeWidth(uint unicode) const;
+    void normaliseSelection();
 
     int mFontHeight;
     int mFontWidth;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -268,7 +268,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // option areas
     mpErrorConsole = new TConsole(mpHost, TConsole::ErrorConsole, this);
     mpErrorConsole->setWrapAt(100);
-    mpErrorConsole->mUpperPane->slot_toggleTimeStamps();
+    mpErrorConsole->mUpperPane->slot_toggleTimeStamps(true);
+    mpErrorConsole->mLowerPane->slot_toggleTimeStamps(true);
     mpErrorConsole->print(tr("*** starting new session ***\n"));
     mpErrorConsole->setMinimumHeight(100);
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);


### PR DESCRIPTION
I've worked my way through the selection/deselection highlighting code and have come up with something that seems to work

It reduces the space allocated on the left of the console for the time stamps as they were being given 15 spaces but only need 13 - which was confusing me as I was working out where the mouse click was over the text.

As it happens this should eliminate the need for https://github.com/Mudlet/Mudlet/pull/2980 and might improve things independently of https://github.com/Mudlet/Mudlet/pull/2943 ...