### PR TITLE
Revise: make the list of default games a public compile time constant

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1558,8 +1558,6 @@ void dlgConnectionProfiles::fillout_form()
 
 void dlgConnectionProfiles::setProfileIcon() const
 {
-    const auto defaultGames = mudlet::self()->getDefaultGames();
-
     for (int i = 0; i < mProfileList.size(); i++) {
         const QString& profileName = mProfileList.at(i);
         if (profileName.isEmpty()) {
@@ -1573,7 +1571,7 @@ void dlgConnectionProfiles::setProfileIcon() const
             // necessarily case preserving for file names so any tests on them
             // should be case insensitive
             // skip creating icons for default MUDs as they are already created above
-            if (defaultGames.contains(profileName, Qt::CaseInsensitive)) {
+            if (mudlet::scmDefaultGames.contains(profileName, Qt::CaseInsensitive)) {
                 continue;
             }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2424,7 +2424,7 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 void mudlet::startAutoLogin(const QString& cliProfile)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-    hostList += mudlet::self()->getDefaultGames();
+    hostList += mudlet::scmDefaultGames;
     hostList.removeDuplicates();
     bool openedProfile = false;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -430,31 +430,32 @@ public:
     // Options dialog when there's no active host
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
 
-    inline static const QStringList scmDefaultGames {QStringLiteral("3Kingdoms"),
-                                                     QStringLiteral("3Scapes"),
-                                                     QStringLiteral("Aardwolf"),
-                                                     QStringLiteral("Achaea"),
-                                                     QStringLiteral("Aetolia"),
-                                                     QStringLiteral("Avalon.de"),
-                                                     QStringLiteral("BatMUD"),
-                                                     QStringLiteral("Clessidra"),
-                                                     QStringLiteral("Fierymud"),
-                                                     QStringLiteral("Imperian"),
-                                                     QStringLiteral("Luminari"),
-                                                     QStringLiteral("Lusternia"),
-                                                     QStringLiteral("Materia Magica"),
-                                                     QStringLiteral("Midnight Sun 2"),
-                                                     QStringLiteral("Realms of Despair"),
-                                                     QStringLiteral("Reinos de Leyenda"),
-                                                     QStringLiteral("StickMUD"),
-                                                     QStringLiteral("WoTMUD"),
-                                                     QStringLiteral("ZombieMUD"),
-                                                     QStringLiteral("Carrion Fields"),
-                                                     QStringLiteral("Cleft of Dimensions"),
-                                                     QStringLiteral("CoreMUD"),
-                                                     QStringLiteral("God Wars II"),
-                                                     QStringLiteral("Slothmud"),
-                                                     QStringLiteral("Legends of the Jedi")};
+    inline static const QStringList scmDefaultGames {
+        "3Scapes",
+        "Aardwolf",
+        "Achaea",
+        "Aetolia",
+        "Avalon.de",
+        "BatMUD",
+        "Clessidra",
+        "Fierymud",
+        "Imperian",
+        "Luminari",
+        "Lusternia",
+        "Materia Magica",
+        "Midnight Sun 2",
+        "Realms of Despair",
+        "Reinos de Leyenda",
+        "StickMUD",
+        "WoTMUD",
+        "ZombieMUD",
+        "Carrion Fields",
+        "Cleft of Dimensions",
+        "CoreMUD",
+        "God Wars II",
+        "Slothmud",
+        "Legends of the Jedi"
+    };
 
 public slots:
     void processEventLoopHack_timerRun();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -258,7 +258,6 @@ public:
     void stopSounds();
     void playSound(const QString &s, int);
     QStringList getAvailableFonts();
-    const QStringList& getDefaultGames() const { return mDefaultGames; }
     std::pair<bool, QString> setProfileIcon(const QString& profile, const QString& newIconPath);
     std::pair<bool, QString> resetProfileIcon(const QString& profile);
 #if defined(Q_OS_WIN32)
@@ -431,6 +430,31 @@ public:
     // Options dialog when there's no active host
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
 
+    inline static const QStringList scmDefaultGames {QStringLiteral("3Kingdoms"),
+                                                     QStringLiteral("3Scapes"),
+                                                     QStringLiteral("Aardwolf"),
+                                                     QStringLiteral("Achaea"),
+                                                     QStringLiteral("Aetolia"),
+                                                     QStringLiteral("Avalon.de"),
+                                                     QStringLiteral("BatMUD"),
+                                                     QStringLiteral("Clessidra"),
+                                                     QStringLiteral("Fierymud"),
+                                                     QStringLiteral("Imperian"),
+                                                     QStringLiteral("Luminari"),
+                                                     QStringLiteral("Lusternia"),
+                                                     QStringLiteral("Materia Magica"),
+                                                     QStringLiteral("Midnight Sun 2"),
+                                                     QStringLiteral("Realms of Despair"),
+                                                     QStringLiteral("Reinos de Leyenda"),
+                                                     QStringLiteral("StickMUD"),
+                                                     QStringLiteral("WoTMUD"),
+                                                     QStringLiteral("ZombieMUD"),
+                                                     QStringLiteral("Carrion Fields"),
+                                                     QStringLiteral("Cleft of Dimensions"),
+                                                     QStringLiteral("CoreMUD"),
+                                                     QStringLiteral("God Wars II"),
+                                                     QStringLiteral("Slothmud"),
+                                                     QStringLiteral("Legends of the Jedi")};
 
 public slots:
     void processEventLoopHack_timerRun();
@@ -652,32 +676,6 @@ private:
 
     // Whether multi-view is in effect:
     bool mMultiView;
-
-    const QStringList mDefaultGames = {"3Kingdoms",
-                                       "3Scapes",
-                                       "Aardwolf",
-                                       "Achaea",
-                                       "Aetolia",
-                                       "Avalon.de",
-                                       "BatMUD",
-                                       "Clessidra",
-                                       "Fierymud",
-                                       "Imperian",
-                                       "Luminari",
-                                       "Lusternia",
-                                       "Materia Magica",
-                                       "Midnight Sun 2",
-                                       "Realms of Despair",
-                                       "Reinos de Leyenda",
-                                       "StickMUD",
-                                       "WoTMUD",
-                                       "ZombieMUD",
-                                       "Carrion Fields",
-                                       "Cleft of Dimensions",
-                                       "CoreMUD",
-                                       "God Wars II",
-                                       "Slothmud",
-                                       "Legends of the Jedi"};
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)


### PR DESCRIPTION
You could replace the `QStringList(...)` wrappers around each game name with `{...}` but I am not entirely sure whether the latter will have *exactly* the same effect.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>