### PR TITLE
fix: Prevent crash in MXP watchdog callback with proper cleanup and guards

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -189,6 +189,9 @@ TBuffer::TBuffer(Host* pH, TConsole* pConsole)
 
 TBuffer::~TBuffer()
 {
+    if (mTagWatchdog) {
+        mTagWatchdog->stop();
+    }
 }
 
 TBuffer::TBuffer(const TBuffer& other)
@@ -1426,6 +1429,11 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
 
 void TBuffer::processMxpWatchdogCallback()
 {
+    if (!mpHost) {
+        mWatchdogPhase = WatchdogPhase::None;
+        return;
+    }
+
     TMxpNodeBuilder&    tagBuilder = mpHost->mMxpProcessor.getMxpTagBuilder();
     std::string         currentTagContent = tagBuilder.getRawTagContent();
     bool                isMxpParserFrozen = !currentTagContent.empty()
@@ -1437,11 +1445,16 @@ void TBuffer::processMxpWatchdogCallback()
         mWatchdogPhase = WatchdogPhase::Phase2_Unfreeze;
         mTagWatchdog->start(MAX_TAG_TIMEOUT_MS);
     } else if (mWatchdogPhase == WatchdogPhase::Phase2_Unfreeze) {
-        if (isMxpParserFrozen) {
+        if (isMxpParserFrozen && mpConsole) {
             mpHost->mMxpProcessor.setLastEntityValue(QString::fromStdString('<' + currentTagContent));
-            QTimer::singleShot(0, [this] () {
-                const TChar style(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
-                QString     lastEntityValue = mpHost->mMxpProcessor.getEntityValue();
+            const TChar style(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
+            QPointer<Host> hostGuard = mpHost;
+            QPointer<TConsole> consoleGuard = mpConsole;
+            QTimer::singleShot(0, mpConsole, [this, style, hostGuard, consoleGuard] () {
+                if (!hostGuard || !consoleGuard) {
+                    return;
+                }
+                QString     lastEntityValue = hostGuard->mMxpProcessor.getEntityValue();
                 size_t      unusedBufferPosition = 0;
 
                 mMudLine.append(lastEntityValue);
@@ -1449,8 +1462,8 @@ void TBuffer::processMxpWatchdogCallback()
                     mMudBuffer.push_back(style);
                 }
                 commitLine('\r', unusedBufferPosition);
-                mpHost->mMxpProcessor.getMxpTagBuilder().reset();
-                mpHost->mpConsole->finalize();
+                hostGuard->mMxpProcessor.getMxpTagBuilder().reset();
+                consoleGuard->finalize();
             });
         }
         mWatchdogPhase = WatchdogPhase::None;


### PR DESCRIPTION
Fixes three critical issues in processMxpWatchdogCallback() that could cause
crashes when TBuffer, Host, or TConsole objects are destroyed while the MXP
watchdog timer is active:

1. Added null pointer check for mpHost at function entry to prevent
   dereferencing a null QPointer when Host is destroyed

2. Stop mTagWatchdog timer in TBuffer destructor to prevent timer callbacks
   from firing after TBuffer destruction

3. Fixed QTimer::singleShot to use mpConsole as receiver (second parameter),
   which automatically cancels pending events if the console is destroyed.
   Also added QPointer guards for both Host and TConsole within the lambda
   to safely handle destruction during deferred execution

4. Compute TChar style before the lambda to avoid calling
   computeCurrentAttributeFlags() which accesses mpHost after potential
   destruction

5. Added mpConsole null check before scheduling the deferred work

These changes prevent the crash scenario where:
- MXP processing detects a stuck tag and starts watchdog timer
- User closes profile/disconnects, destroying Host/TConsole/TBuffer
- Timer callback or deferred singleShot fires on deleted objects

Related: https://mudlet.sentry.io/share/issue/d888ca4582594f6a900e26e96611b43e/